### PR TITLE
Add pull request template for Japanese review guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!-- I want to review in Japanese. -->
+
+## レビューに関して
+
+レビューする際には、以下の prefix(接頭辞)を付けましょう。
+
+<!-- for GitHub Copilot review rule -->
+
+[must] → かならず変更してね  
+[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)  
+[nits] → ささいな指摘(nitpick)
+[ask] → 質問  
+[fyi] → 参考情報
+
+<!-- for GitHub Copilot review rule-->
+
+## PR のルール
+
+- まずは Draft で PR を作成する。
+- レビューに出せる状態になったら Open にする。（レビュワーがランダムにアサインされます）
+- レビューなしでの main ブランチへのマージは原則禁止


### PR DESCRIPTION
This pull request introduces a new section in the pull request template to facilitate reviews in Japanese. It includes guidelines for adding prefixes to comments and outlines the rules for creating and submitting pull requests.

Changes to the pull request template:

* [`.github/PULL_REQUEST_TEMPLATE.md`](diffhunk://#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35R1-R21): Added a section for reviewing in Japanese, including prefixes for comments such as `[must]`, `[imo]`, `[nits]`, `[ask]`, and `[fyi]`. Also added rules for creating and submitting pull requests, such as starting with a draft and prohibiting merging to the main branch without review.